### PR TITLE
Conform to Ruby style guide on %r

### DIFF
--- a/lib/guard/rubocop/templates/Guardfile
+++ b/lib/guard/rubocop/templates/Guardfile
@@ -1,4 +1,4 @@
 guard :rubocop do
-  watch(%r{.+\.rb$})
-  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+  watch(/.+\.rb$/)
+  watch(/(?:.+\/)?\.rubocop\.yml$/) { |m| File.dirname(m[1]) }
 end


### PR DESCRIPTION
Prior to this change rubocop gives:

```
Guardfile:26:9: C: Use %r only for regular expressions matching more than 1 '/' character.
  watch(%r{.+\.rb$})
        ^^^^^^^^^^^
Guardfile:27:9: C: Use %r only for regular expressions matching more than 1 '/' character.
  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
