### PR TITLE
Support for Launchy

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ all_on_start: true     # Check all files at Guard startup.
 cli: '--rails'         # Pass arbitrary RuboCop CLI arguments.
                        # An array or string is acceptable.
                        #   default: nil
-hide_stdout: false      # Do not display console output (in case outputting to file).
+hide_stdout: false     # Do not display console output (in case outputting to file).
                        #   default: false
 keep_failed: true      # Keep failed files until they pass.
                        #   default: true
@@ -71,6 +71,19 @@ notification: :failed  # Display Growl notification after each run.
                        #   false   - Never notify
                        #   :failed - Notify only when failed
                        #   default: :failed
+launchy: nil           # Filename to launch using Launchy after RuboCop runs.
+                       #   default: nil
+```
+
+### Using Launchy to view results
+
+guard-rubocop can be configured to launch a results file in lieu of or in addition to outputing results to the terminal.
+Configure your Guardfile with the launchy option:
+
+``` ruby
+guard :rubocop, cli: %w(--format fuubar --format html -o ./tmp/rubocop_results.html), launchy: './tmp/rubocop_results.html' do
+  # ...
+end
 ```
 
 ## Advanced Tips

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = (ENV['CI'] == 'true')
+end
+
 RuboCop::RakeTask.new(:style)
 
 namespace :ci do

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov',   '~> 0.7'
   spec.add_development_dependency 'guard-rspec', '>= 4.2.3', '< 5.0'
   spec.add_development_dependency 'ruby_gntp',   '~> 0.3'
+  spec.add_development_dependency 'launchy',     '~> 2.4'
 end

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'guard',   '~> 2.0'
+  spec.add_runtime_dependency 'guard-compat',   '~> 1.1'
   spec.add_runtime_dependency 'rubocop', '~> 0.20'
 
   spec.add_development_dependency 'bundler',     '~> 1.3'
   spec.add_development_dependency 'rake',        '~> 10.0'
-  spec.add_development_dependency 'rspec',       '~> 3.0'
+  spec.add_development_dependency 'rspec',       '~> 3.1'
   spec.add_development_dependency 'simplecov',   '~> 0.7'
   spec.add_development_dependency 'guard-rspec', '>= 4.2.3', '< 5.0'
   spec.add_development_dependency 'ruby_gntp',   '~> 0.3'

--- a/lib/guard/rubocop.rb
+++ b/lib/guard/rubocop.rb
@@ -1,7 +1,8 @@
 # coding: utf-8
 
-require 'guard'
-require 'guard/plugin'
+require 'tempfile'
+
+require 'guard/compat/plugin'
 
 module Guard
   # This class gets API calls from `guard` and runs `rubocop` command via {Guard::RuboCop::Runner}.
@@ -30,7 +31,7 @@ module Guard
     end
 
     def run_all
-      UI.info 'Inspecting Ruby code style of all files'
+      Compat::UI.info 'Inspecting Ruby code style of all files'
       inspect_with_rubocop
     end
 
@@ -55,7 +56,7 @@ module Guard
       return if paths.empty?
 
       displayed_paths = paths.map { |path| smart_path(path) }
-      UI.info "Inspecting Ruby code style: #{displayed_paths.join(' ')}"
+      Compat::UI.info "Inspecting Ruby code style: #{displayed_paths.join(' ')}"
 
       inspect_with_rubocop(paths)
     end
@@ -65,8 +66,8 @@ module Guard
       passed = runner.run(paths)
       @failed_paths = runner.failed_paths
       throw :task_has_failed unless passed
-    rescue => error
-      UI.error 'The following exception occurred while running guard-rubocop: ' \
+    rescue StandardError => error
+      Compat::UI.error 'The following exception occurred while running guard-rubocop: ' \
                "#{error.backtrace.first} #{error.message} (#{error.class.name})"
     end
 

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -88,7 +88,7 @@ module Guard
 
       def notify(passed)
         image = passed ? :success : :failed
-        Notifier.notify(summary_text, title: 'RuboCop results', image: image)
+        Compat::UI.notify(summary_text, title: 'RuboCop results', image: image)
       end
 
       def summary_text

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -131,7 +131,7 @@ module Guard
 
       def open_launchy
         return unless @options[:launchy]
-        require "launchy"
+        require 'launchy'
         pn = Pathname.new(@options[:launchy])
         ::Launchy.open(@options[:launchy]) if pn.exist?
       end

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -22,6 +22,8 @@ module Guard
           notify(passed)
         end
 
+        open_launchy
+
         passed
       end
 
@@ -125,6 +127,13 @@ module Guard
         text << 's' unless number == 1
 
         text
+      end
+
+      def open_launchy
+        return unless @options[:launchy]
+        require "launchy"
+        pn = Pathname.new(@options[:launchy])
+        ::Launchy.open(@options[:launchy]) if pn.exist?
       end
     end
   end

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-require 'spec_helper.rb'
+require 'guard/compat/test/helper'
 
-describe Guard::RuboCop::Runner do
+require 'guard/rubocop'
+
+RSpec.describe Guard::RuboCop::Runner do
   subject(:runner) { Guard::RuboCop::Runner.new(options) }
   let(:options) { {} }
 
@@ -345,14 +347,14 @@ describe Guard::RuboCop::Runner do
     end
 
     it 'notifies summary' do
-      expect(Guard::Notifier).to receive(:notify) do |message, _options|
+      expect(Guard::Compat::UI).to receive(:notify) do |message, _options|
         expect(message).to eq('2 files inspected, 4 offenses detected')
       end
       runner.notify(true)
     end
 
     it 'notifies with title "RuboCop results"' do
-      expect(Guard::Notifier).to receive(:notify) do |_message, options|
+      expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
         expect(options[:title]).to eq('RuboCop results')
       end
       runner.notify(true)
@@ -360,7 +362,7 @@ describe Guard::RuboCop::Runner do
 
     context 'when passed' do
       it 'shows success image' do
-        expect(Guard::Notifier).to receive(:notify) do |_message, options|
+        expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
           expect(options[:image]).to eq(:success)
         end
         runner.notify(true)
@@ -369,7 +371,7 @@ describe Guard::RuboCop::Runner do
 
     context 'when failed' do
       it 'shows failed image' do
-        expect(Guard::Notifier).to receive(:notify) do |_message, options|
+        expect(Guard::Compat::UI).to receive(:notify) do |_message, options|
           expect(options[:image]).to eq(:failed)
         end
         runner.notify(false)

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -2,6 +2,8 @@
 
 require 'guard/compat/test/helper'
 
+require "launchy"
+
 require 'guard/rubocop'
 
 RSpec.describe Guard::RuboCop::Runner do
@@ -90,6 +92,20 @@ RSpec.describe Guard::RuboCop::Runner do
     context 'when :notification option is false' do
       let(:options) { { notification: false } }
       include_examples 'notification', { passed: false, failed: false }
+    end
+
+    context "when :launchy option is present" do
+      let(:options) { { launchy: "launchy_path" } }
+
+      before do
+        allow(Pathname).to receive(:new).
+          with("launchy_path") { double(exist?: true) }
+      end
+
+      it "opens Launchy" do
+        expect(Launchy).to receive(:open).with("launchy_path")
+        runner.run(paths)
+      end
     end
   end
 

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -2,7 +2,7 @@
 
 require 'guard/compat/test/helper'
 
-require "launchy"
+require 'launchy'
 
 require 'guard/rubocop'
 
@@ -94,16 +94,15 @@ RSpec.describe Guard::RuboCop::Runner do
       include_examples 'notification', { passed: false, failed: false }
     end
 
-    context "when :launchy option is present" do
-      let(:options) { { launchy: "launchy_path" } }
+    context 'when :launchy option is present' do
+      let(:options) { { launchy: 'launchy_path' } }
 
       before do
-        allow(Pathname).to receive(:new).
-          with("launchy_path") { double(exist?: true) }
+        allow(Pathname).to receive(:new).with('launchy_path') { double(exist?: true) }
       end
 
-      it "opens Launchy" do
-        expect(Launchy).to receive(:open).with("launchy_path")
+      it 'opens Launchy' do
+        expect(Launchy).to receive(:open).with('launchy_path')
         runner.run(paths)
       end
     end

--- a/spec/guard/rubocop/template_spec.rb
+++ b/spec/guard/rubocop/template_spec.rb
@@ -1,0 +1,18 @@
+require 'guard/compat/test/template'
+
+require 'guard/rubocop'
+
+RSpec.describe Guard::RuboCop do
+  describe 'template' do
+    subject { Guard::Compat::Test::Template.new(described_class) }
+
+    it 'matches Ruby files' do
+      expect(subject.changed('lib/foo.rb')).to eq(%w(lib/foo.rb))
+    end
+
+    it 'matches .rubocop.yml files' do
+      expect(subject.changed('.rubocop.yml')).to eq(%w(.))
+      expect(subject.changed('foo/.rubocop.yml')).to eq(%w(foo))
+    end
+  end
+end

--- a/spec/guard/rubocop_spec.rb
+++ b/spec/guard/rubocop_spec.rb
@@ -1,10 +1,13 @@
 # coding: utf-8
 
-require 'spec_helper.rb'
-
-describe Guard::RuboCop, :silence_output do
+RSpec.describe Guard::RuboCop, :silence_output do
   subject(:guard) { Guard::RuboCop.new(options) }
   let(:options) { {} }
+
+  before do
+    allow(Guard::Compat::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:error)
+  end
 
   describe '#options' do
     subject { super().options }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,26 @@
-# coding: utf-8
-
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  config.mock_with :rspec do |c|
-    c.syntax = :expect
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
   end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end
 
 Dir[File.join(File.dirname(__FILE__), 'support', '*')].each do |path|
@@ -29,5 +42,3 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end
-
-require 'guard/rubocop'

--- a/spec/support/silence_output.rb
+++ b/spec/support/silence_output.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-shared_context 'silence output', silence_output: true do
+RSpec.shared_context 'silence output', silence_output: true do
   null_object = BasicObject.new
 
   class << null_object


### PR DESCRIPTION
_This PR relies on the changes that are in #19, so that PR must be merged before this one._

Add support for the `launchy` option, which mirrors behavior that the guard-rspec plugin supports. For example:

``` ruby
guard :rubocop, cli: %w(--format fuubar --format html -o ./tmp/rubocop_results.html), launchy: './tmp/rubocop_results.html' do
  # ...
end
```

This will cause the Rubocop results to be opened in the default browser when the guard runs, in addition to being output in the terminal.
