### PR TITLE
Update rubocop dependency to '~> 0.3'

### DIFF
--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'guard',   '~> 2.0'
-  spec.add_runtime_dependency 'rubocop', '~> 0.20'
+  spec.add_runtime_dependency 'rubocop', '~> 0.30'
 
   spec.add_development_dependency 'bundler',     '~> 1.3'
   spec.add_development_dependency 'rake',        '~> 10.0'


### PR DESCRIPTION
Rubocop is now at version 0.33 so this guard should be updated accordingly