### PR TITLE
Allow `:cmd` option for changing path to binary

### DIFF
--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -26,7 +26,8 @@ module Guard
       end
 
       def build_command(paths)
-        command = ['rubocop']
+        command = @options[:cmd] || 'rubocop'
+        command = [command]
 
         if should_add_default_formatter_for_console?
           command.concat(%w(--format progress)) # Keep default formatter for console.


### PR DESCRIPTION
I need rubocop to be run via binstub in my project, so I added the ability to pass a `cmd` option. What do you think?
