### PR TITLE
Fix line that caused Rubocop to fail

### DIFF
--- a/lib/guard/rubocop/templates/Guardfile
+++ b/lib/guard/rubocop/templates/Guardfile
@@ -1,4 +1,4 @@
 guard :rubocop do
-  watch(%r{.+\.rb$})
+  watch(/.+\.rb/)
   watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
 end


### PR DESCRIPTION
The modified line was causing Rubocop (with default configuration) to fail because of this rule:

https://github.com/bbatsov/ruby-style-guide#percent-r