### PR TITLE
Use --parallel option of rubocop

### DIFF
--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -34,6 +34,7 @@ module Guard
 
         command.concat(['--format', 'json', '--out', json_file_path])
         command << '--force-exclusion'
+        command << '--parallel'
         command.concat(args_specified_by_user)
         command.concat(paths)
       end

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Guard::RuboCop::Runner do
     end
 
     it 'adds args specified by user' do
-      expect(build_command[8..9]).to eq(%w[--debug --rails])
+      expect(build_command[9..10]).to eq(%w[--debug --rails])
     end
 
     it 'adds the passed paths' do
-      expect(build_command[10..-1]).to eq(%w[file1.rb file2.rb])
+      expect(build_command[11..-1]).to eq(%w[file1.rb file2.rb])
     end
   end
 


### PR DESCRIPTION
The option was apparently introduced in RuboCop 0.49 in this May.