### PR TITLE
CI against Ruby 2.2.8/2.3.5/2.4.2/JRuby 9.1.13.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,10 +19,6 @@ Naming/HeredocDelimiterNaming:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
-Style/Encoding:
-  Enabled: true
-  EnforcedStyle: never
-
 Style/MethodMissing:
   Exclude:
     - spec/support/silence_output.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - jruby-9.1.10.0
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - jruby-9.1.13.0
 script:
   - bundle exec rake ci
 sudo: false

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '~> 0.20'
 
   spec.add_development_dependency 'bundler',     '~> 1.3'
+  spec.add_development_dependency 'guard-rspec', '>= 4.2.3', '< 5.0'
+  spec.add_development_dependency 'launchy',     '~> 2.4'
   spec.add_development_dependency 'rake',        '~> 12.0'
   spec.add_development_dependency 'rspec',       '~> 3.0'
-  spec.add_development_dependency 'simplecov',   '~> 0.7'
-  spec.add_development_dependency 'guard-rspec', '>= 4.2.3', '< 5.0'
   spec.add_development_dependency 'ruby_gntp',   '~> 0.3'
-  spec.add_development_dependency 'launchy',     '~> 2.4'
+  spec.add_development_dependency 'simplecov',   '~> 0.7'
 end


### PR DESCRIPTION
This PR includes the following changes

- Remove unnecessary Style/Encoding
  As of RuboCop v0.50.0, the Style/Encoding cop is now enabled by default
  and configured to remove the encoding magic-comment.
  Details here: bbatsov/rubocop#4445

- rubocop --auto-correct --only Gemspec/OrderedDependencies
  Gemspec/OrderedDependencies is enabled from 0.51.0
  bbatsov/rubocop#4874
